### PR TITLE
[bug] use clusterid-containerid as container's veth.pair name

### DIFF
--- a/conf/container.conf
+++ b/conf/container.conf
@@ -23,7 +23,8 @@ lxc.utsname = %HOSTNAME%
 
 lxc.network.type = veth
 lxc.network.name = eth0
-lxc.network.veth.pair = %LXCNAME%
+# veth.pair is limited in 16 bytes
+lxc.network.veth.pair = %VETHPAIR%
 lxc.network.script.up = Bridge=docklet-br VLANID=%VLANID% %LXCSCRIPT%/lxc-ifup
 lxc.network.script.down = Bridge=docklet-br %LXCSCRIPT%/lxc-ifdown
 lxc.network.ipv4 = %IP%

--- a/src/container.py
+++ b/src/container.py
@@ -4,7 +4,7 @@ import subprocess, os, json
 import imagemgr
 from log import logger
 import env
-from lvmtool import *
+from lvmtool import sys_run, check_volume
 
 class Container(object):
     def __init__(self, addr, etcdclient):
@@ -21,7 +21,7 @@ class Container(object):
         self.lxcpath = "/var/lib/lxc"
         self.imgmgr = imagemgr.ImageMgr()
 
-    def create_container(self, lxc_name, username, user_info, clustername, clusterid, hostname, ip, gateway, vlanid, image):
+    def create_container(self, lxc_name, username, user_info, clustername, clusterid, containerid, hostname, ip, gateway, vlanid, image):
         logger.info("create container %s of %s for %s" %(lxc_name, clustername, username))
         try:
             user_info = json.loads(user_info) 
@@ -65,6 +65,7 @@ class Container(object):
             conftext = conftext.replace("%LXCNAME%",lxc_name)
             conftext = conftext.replace("%VLANID%",str(vlanid))
             conftext = conftext.replace("%CLUSTERNAME%", clustername)
+            conftext = conftext.replace("%VETHPAIR%", str(clusterid)+'-'+str(containerid))
 
             conffile = open("/var/lib/lxc/%s/config" % lxc_name,"w")
             conffile.write(conftext)

--- a/src/vclustermgr.py
+++ b/src/vclustermgr.py
@@ -84,7 +84,7 @@ class VclusterMgr(object):
             lxc_name = username + "-" + str(clusterid) + "-" + str(i)
             hostname = "host-"+str(i)
             logger.info ("create container with : name-%s, username-%s, clustername-%s, clusterid-%s, hostname-%s, ip-%s, gateway-%s, image-%s" % (lxc_name, username, clustername, str(clusterid), hostname, ips[i], gateway, image_json))
-            [success,message] = onework.create_container(lxc_name, username, user_info , clustername, str(clusterid), hostname, ips[i], gateway, str(vlanid), image_json)
+            [success,message] = onework.create_container(lxc_name, username, user_info , clustername, str(clusterid), str(i), hostname, ips[i], gateway, str(vlanid), image_json)
             if success is False:
                 logger.info("container create failed, so vcluster create failed")
                 return [False, message]
@@ -124,7 +124,7 @@ class VclusterMgr(object):
         onework = workers[random.randint(0, len(workers)-1)]
         lxc_name = username + "-" + str(clusterid) + "-" + str(cid)
         hostname = "host-" + str(cid)
-        [success, message] = onework.create_container(lxc_name, username, user_info, clustername, clusterid, hostname, ip, gateway, str(vlanid), image_json)
+        [success, message] = onework.create_container(lxc_name, username, user_info, clustername, clusterid, str(cid), hostname, ip, gateway, str(vlanid), image_json)
         if success is False:
             logger.info("create container failed, so scale out failed")
             return [False, message]


### PR DESCRIPTION
**bug**  #19 
use clusterid-containerid as container's veth.pair name      
because lxc config item length limit in 16 bytes
