### PR TITLE
add two scripts for starting and stoping spark cluster

### DIFF
--- a/tools/dl_start_spark.sh
+++ b/tools/dl_start_spark.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# a naive script to fast start spark cluster, assuming host-0 master,
+# others slaves.
+# used with dl_stop_spark.sh
+
+SPARK_HOME=/home/spark
+
+HOSTS=`grep -v localhost /etc/hosts | awk '{print $2}'`
+
+echo "Starting master in host-0"
+
+$SPARK_HOME/sbin/start-master.sh
+
+for h in $HOSTS ; do
+    echo "Starting slave in $h"
+    if [ $h  != 'host-0' ] ; then
+        ssh root@$h /home/spark/sbin/start-slave.sh spark://host-0:7077
+    else
+        /home/spark/sbin/start-slave.sh spark://host-0:7077
+    fi
+done

--- a/tools/dl_stop_spark.sh
+++ b/tools/dl_stop_spark.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# a naive script to stop spark cluster, assuming host-0 master
+# others slaves
+# used with dl_start_spark.sh
+
+SPARK_HOME=/home/spark
+
+HOSTS=`grep -v localhost /etc/hosts | awk '{print $2}'`
+
+for h in $HOSTS ; do
+    echo "Stopping slave in $h"
+    if [ $h  != 'host-0' ] ; then
+        ssh root@$h /home/spark/sbin/stop-slave.sh
+    else
+        /home/spark/sbin/stop-slave.sh 
+    fi
+done
+
+echo "Stopping master in host-0"
+
+$SPARK_HOME/sbin/stop-master.sh
+

--- a/tools/update-basefs.sh
+++ b/tools/update-basefs.sh
@@ -119,3 +119,8 @@ Host *
     UserKnownHostsFile=/dev/null
 EOF
 done
+
+echo "[*] Generating $BASEFS/home/spark/sbin/dl_{start|stop}_spark.sh for Spark"
+if [ -d $BASEFS/home/spark/sbin ] ; then
+    cp dl_*_spark.sh $BASEFS/home/spark/sbin
+fi


### PR DESCRIPTION
admin should run tools/update-basefs.sh to generate the two scripts.  
users use dl_start_spark.sh to start spark cluster, and dl_stop_spark.sh to stop spark cluster.