### PR TITLE
vlan ids reusing

### DIFF
--- a/src/httprest.py
+++ b/src/httprest.py
@@ -203,8 +203,10 @@ class DockletHttpHandler(http.server.BaseHTTPRequestHandler):
                 else:
                     self.response(200, {'success':'false', 'action':'stop cluster', 'message':result})
             elif cmds[1] == 'delete':
+                user_info = G_usermgr.selfQuery(cur_user = cur_user)
+                user_info = json.dumps(user_info)
                 logger.info ("handle request : delete cluster %s" % clustername)
-                [status, result] = G_vclustermgr.delete_cluster(clustername, user)
+                [status, result] = G_vclustermgr.delete_cluster(clustername, user, user_info)
                 if status:
                     self.response(200, {'success':'true', 'action':'delete cluster', 'message':result})
                 else:

--- a/src/network.py
+++ b/src/network.py
@@ -273,6 +273,8 @@ class NetworkMgr(object):
         self.etcd.setkey("network/vlanids/"+str(i+1), json.dumps(self.vlanids['currentpool']))
         self.etcd.setkey("network/vlanids/current", str(i+1))
     
+    # Data Structure:
+    # shared_vlanids = [{vlanid = ..., sharenum = ...}, {vlanid = ..., sharenum = ...}, ...]
     def init_shared_vlanids(self, vlannum = 128, sharenum = 128):
         self.shared_vlanids = []
         for i in range(vlannum):
@@ -352,6 +354,9 @@ class NetworkMgr(object):
 
     def acquire_vlanid(self, isshared = False):
         if isshared:
+            # only share vlanid of the front entry
+            # if sharenum is reduced to 0, move the front entry to the back
+            # if sharenum is still equal to 0, one round of sharing is complete, start another one
             if self.shared_vlanids[0]['sharenum'] == 0:
                 self.shared_vlanids.append(self.shared_vlanids.pop(0))
             if self.shared_vlanids[0]['sharenum'] == 0:

--- a/src/network.py
+++ b/src/network.py
@@ -412,11 +412,11 @@ class NetworkMgr(object):
         return [True, 'add user success']
 
     def del_user(self, username, isshared = False):
-        logger.info ("delete user %s with cidr=%s" % (username))
         if not self.has_user(username):
             return [False, username+" not in users set"]
         self.load_user(username)
         [addr, cidr] = self.users[username].info.split('/')
+        logger.info ("delete user %s with cidr=%s" % (username, int(cidr)))
         self.center.free(addr, int(cidr))
         self.dump_center()
         if not isshared:

--- a/src/vclustermgr.py
+++ b/src/vclustermgr.py
@@ -55,7 +55,7 @@ class VclusterMgr(object):
     def create_cluster(self, clustername, username, image, user_info):
         if self.is_cluster(clustername, username):
             return [False, "cluster:%s already exists" % clustername]
-        clustersize = int(self.defaultsize);
+        clustersize = int(self.defaultsize)
         logger.info ("starting cluster %s with %d containers for %s" % (clustername, int(clustersize), username))
         workers = self.nodemgr.get_rpcs()
         image_json = json.dumps(image)
@@ -143,7 +143,7 @@ class VclusterMgr(object):
         clusterfile.write(json.dumps(clusterinfo))
         clusterfile.close()
         return [True, clusterinfo]
-    
+
     def addproxy(self,username,clustername,ip,port):
         [status, clusterinfo] = self.get_clusterinfo(clustername, username)
         if 'proxy_ip' in clusterinfo:
@@ -234,7 +234,7 @@ class VclusterMgr(object):
         infofile.close()
         return res
 
-    def delete_cluster(self, clustername, username):
+    def delete_cluster(self, clustername, username, user_info):
         [status, info] = self.get_clusterinfo(clustername, username)
         if not status:
             return [False, "cluster not found"]
@@ -250,6 +250,13 @@ class VclusterMgr(object):
         self.networkmgr.printpools()
         os.remove(self.fspath+"/global/users/"+username+"/clusters/"+clustername)
         os.remove(self.fspath+"/global/users/"+username+"/hosts/"+str(info['clusterid'])+".hosts")
+        
+        groupname = json.loads(user_info)["data"]["group"]
+        [status, clusters] = self.list_clusters[username]
+        if len(clusters) == 0:
+            self.networkmgr.del_user(username, isshared = True if str(groupname) == "fundation" else False)
+            logger.info("vlanid release triggered")
+        
         return [True, "cluster delete"]
 
     def scale_in_cluster(self, clustername, username, containername):

--- a/src/vclustermgr.py
+++ b/src/vclustermgr.py
@@ -252,7 +252,7 @@ class VclusterMgr(object):
         os.remove(self.fspath+"/global/users/"+username+"/hosts/"+str(info['clusterid'])+".hosts")
         
         groupname = json.loads(user_info)["data"]["group"]
-        [status, clusters] = self.list_clusters[username]
+        [status, clusters] = self.list_clusters(username)
         if len(clusters) == 0:
             self.networkmgr.del_user(username, isshared = True if str(groupname) == "fundation" else False)
             logger.info("vlanid release triggered")


### PR DESCRIPTION
release unshared vlan ids by deleting the user from the network database when the user has no workspace/vcluster