### PR TITLE
Vxlan simple

### DIFF
--- a/bin/docklet-master
+++ b/bin/docklet-master
@@ -34,6 +34,8 @@ CLUSTER_NAME=docklet-vc
 WEB_PORT=8888
 #cluster net, default is 172.16.0.1/16
 CLUSTER_NET="172.16.0.1/16"
+#virtual network number, default is 4094
+VNET_COUNT=4094
 
 . $DOCKLET_CONF/docklet.conf
 

--- a/conf/container.conf
+++ b/conf/container.conf
@@ -25,8 +25,8 @@ lxc.network.type = veth
 lxc.network.name = eth0
 # veth.pair is limited in 16 bytes
 lxc.network.veth.pair = %VETHPAIR%
-lxc.network.script.up = Bridge=docklet-br-%BRIDGEID% VLANID=%VLANID% MasterIP=%MASTER% %LXCSCRIPT%/lxc-ifup
-lxc.network.script.down = Bridge=docklet-br-%BRIDGEID% %LXCSCRIPT%/lxc-ifdown
+lxc.network.script.up = Bridge=docklet-br-%BRIDGEID% Bridgeid=%BRIDGEID% VLANID=%VLANID% MasterIP=%MASTER% %LXCSCRIPT%/lxc-ifup
+lxc.network.script.down = Bridge=docklet-br-%BRIDGEID% Bridgeid=%BRIDGEID% %LXCSCRIPT%/lxc-ifdown
 lxc.network.ipv4 = %IP%
 lxc.network.ipv4.gateway = %GATEWAY%
 lxc.network.flags = up

--- a/conf/container.conf
+++ b/conf/container.conf
@@ -25,8 +25,8 @@ lxc.network.type = veth
 lxc.network.name = eth0
 # veth.pair is limited in 16 bytes
 lxc.network.veth.pair = %VETHPAIR%
-lxc.network.script.up = Bridge=docklet-user-%VLANID% VLANID=%VLANID% MasterIP=%MASTER% %LXCSCRIPT%/lxc-ifup
-lxc.network.script.down = Bridge=docklet-user-%VLANID% %LXCSCRIPT%/lxc-ifdown
+lxc.network.script.up = Bridge=docklet-br-%BRIDGEID% VLANID=%VLANID% MasterIP=%MASTER% %LXCSCRIPT%/lxc-ifup
+lxc.network.script.down = Bridge=docklet-br-%BRIDGEID% %LXCSCRIPT%/lxc-ifdown
 lxc.network.ipv4 = %IP%
 lxc.network.ipv4.gateway = %GATEWAY%
 lxc.network.flags = up

--- a/conf/container.conf
+++ b/conf/container.conf
@@ -25,8 +25,8 @@ lxc.network.type = veth
 lxc.network.name = eth0
 # veth.pair is limited in 16 bytes
 lxc.network.veth.pair = %VETHPAIR%
-lxc.network.script.up = Bridge=docklet-br VLANID=%VLANID% %LXCSCRIPT%/lxc-ifup
-lxc.network.script.down = Bridge=docklet-br %LXCSCRIPT%/lxc-ifdown
+lxc.network.script.up = Bridge=docklet-user-%VLANID% VLANID=%VLANID% MasterIP=%MASTER% %LXCSCRIPT%/lxc-ifup
+lxc.network.script.down = Bridge=docklet-user-%VLANID% %LXCSCRIPT%/lxc-ifdown
 lxc.network.ipv4 = %IP%
 lxc.network.ipv4.gateway = %GATEWAY%
 lxc.network.flags = up

--- a/conf/docklet.conf.template
+++ b/conf/docklet.conf.template
@@ -145,3 +145,5 @@
 # default: "gluster volume quota docklet-volume limit-usage %s %s"
 # DATA_QUOTA_CMD="gluster volume quota docklet-volume limit-usage %s %s"
 
+# VNET_COUNT : the number of users in a bridge. default 4094
+# VNET_COUNT=4094

--- a/conf/lxc-script/lxc-ifup
+++ b/conf/lxc-script/lxc-ifup
@@ -11,4 +11,6 @@
 ovs-vsctl --may-exist add-br $Bridge
 ovs-vsctl --if-exists del-port $Bridge $5
 ovs-vsctl --may-exist add-port $Bridge $5 tag=$VLANID
-ovs-vsctl --may-exist add-port $Bridge vxlan-$Bridgeid-$MasterIP -- set interface vxlan-$Bridgeid-$MasterIP type=vxlan options:remote_ip=$MasterIP options:key=$Bridgeid
+if [ "ERROR" != "$MasterIP" ]; then
+    ovs-vsctl --may-exist add-port $Bridge vxlan-$Bridgeid-$MasterIP -- set interface vxlan-$Bridgeid-$MasterIP type=vxlan options:remote_ip=$MasterIP options:key=$Bridgeid
+fi

--- a/conf/lxc-script/lxc-ifup
+++ b/conf/lxc-script/lxc-ifup
@@ -10,5 +10,5 @@
 #ovs-vsctl --may-exist add-port $Bridge $5 tag=$VLANID
 ovs-vsctl --may-exist add-br $Bridge
 ovs-vsctl --if-exists del-port $Bridge $5
-ovs-vsctl --may-exist add-port $Bridge $5
+ovs-vsctl --may-exist add-port $Bridge $5 tag=$VLANID
 ovs-vsctl --may-exist add-port $Bridge vxlan-$VLANID-$MasterIP -- set interface vxlan-$VLANID-$MasterIP type=vxlan options:remote_ip=$MasterIP options:key=$VLANID

--- a/conf/lxc-script/lxc-ifup
+++ b/conf/lxc-script/lxc-ifup
@@ -7,4 +7,8 @@
 # $4 : network type, for example, veth
 # $5 : value of lxc.network.veth.pair 
 
-ovs-vsctl --may-exist add-port $Bridge $5 tag=$VLANID
+#ovs-vsctl --may-exist add-port $Bridge $5 tag=$VLANID
+ovs-vsctl --may-exist add-br $Bridge
+ovs-vsctl --if-exists del-port $Bridge $5
+ovs-vsctl --may-exist add-port $Bridge $5
+ovs-vsctl --may-exist add-port $Bridge vxlan$VLANID -- set interface vxlan$VLANID type=vxlan options:remote=$MasterIP options:key=$VLANID

--- a/conf/lxc-script/lxc-ifup
+++ b/conf/lxc-script/lxc-ifup
@@ -11,4 +11,4 @@
 ovs-vsctl --may-exist add-br $Bridge
 ovs-vsctl --if-exists del-port $Bridge $5
 ovs-vsctl --may-exist add-port $Bridge $5
-ovs-vsctl --may-exist add-port $Bridge vxlan$VLANID -- set interface vxlan$VLANID type=vxlan options:remote=$MasterIP options:key=$VLANID
+ovs-vsctl --may-exist add-port $Bridge vxlan-$VLANID-$MasterIP -- set interface vxlan-$VLANID-$MasterIP type=vxlan options:remote_ip=$MasterIP options:key=$VLANID

--- a/conf/lxc-script/lxc-ifup
+++ b/conf/lxc-script/lxc-ifup
@@ -11,4 +11,4 @@
 ovs-vsctl --may-exist add-br $Bridge
 ovs-vsctl --if-exists del-port $Bridge $5
 ovs-vsctl --may-exist add-port $Bridge $5 tag=$VLANID
-ovs-vsctl --may-exist add-port $Bridge vxlan-$VLANID-$MasterIP -- set interface vxlan-$VLANID-$MasterIP type=vxlan options:remote_ip=$MasterIP options:key=$VLANID
+ovs-vsctl --may-exist add-port $Bridge vxlan-$Bridgeid-$MasterIP -- set interface vxlan-$Bridgeid-$MasterIP type=vxlan options:remote_ip=$MasterIP options:key=$Bridgeid

--- a/src/container.py
+++ b/src/container.py
@@ -63,7 +63,7 @@ class Container(object):
                 content = content.replace("%VLANID%",str(vlanid))
                 content = content.replace("%CLUSTERNAME%", clustername)
                 content = content.replace("%VETHPAIR%", str(clusterid)+'-'+str(containerid))
-                content = content.replace("%MASTER", str(self.masterIP))
+                content = content.replace("%MASTER%", str(self.masterIP))
                 return content
 
             conffile = open(self.confpath+"/container.conf", 'r')

--- a/src/container.py
+++ b/src/container.py
@@ -67,7 +67,7 @@ class Container(object):
                 content = content.replace("%CLUSTERNAME%", clustername)
                 content = content.replace("%VETHPAIR%", str(clusterid)+'-'+str(containerid))
                 content = content.replace("%MASTER%", str(self.masterIP))
-                content = content.replace("%BRIDGEID%", str(vlanid / self.bridgeUserSize))
+                content = content.replace("%BRIDGEID%", str(vlanid // self.bridgeUserSize))
                 return content
 
             conffile = open(self.confpath+"/container.conf", 'r')

--- a/src/container.py
+++ b/src/container.py
@@ -20,6 +20,8 @@ class Container(object):
 
         self.lxcpath = "/var/lib/lxc"
         self.imgmgr = imagemgr.ImageMgr()
+        # get Master IP
+        self.masterIP = self.etcd.getkey("service/master")[1]
 
     def create_container(self, lxc_name, username, user_info, clustername, clusterid, containerid, hostname, ip, gateway, vlanid, image):
         logger.info("create container %s of %s for %s" %(lxc_name, clustername, username))
@@ -61,6 +63,7 @@ class Container(object):
                 content = content.replace("%VLANID%",str(vlanid))
                 content = content.replace("%CLUSTERNAME%", clustername)
                 content = content.replace("%VETHPAIR%", str(clusterid)+'-'+str(containerid))
+                content = content.replace("%MASTER", str(self.masterIP))
                 return content
 
             conffile = open(self.confpath+"/container.conf", 'r')

--- a/src/container.py
+++ b/src/container.py
@@ -50,7 +50,7 @@ class Container(object):
             sys_run("mkdir -p /var/lib/lxc/%s" % lxc_name)
             logger.info("generate config file for %s" % lxc_name)
             
-            def config_prepare(content):
+            def config_prepare(content, bridgeUserSize):
                 content = content.replace("%ROOTFS%",rootfs)
                 content = content.replace("%HOSTNAME%",hostname)
                 content = content.replace("%IP%",ip)
@@ -63,17 +63,17 @@ class Container(object):
                 content = content.replace("%LXCSCRIPT%",env.getenv("LXC_SCRIPT"))
                 content = content.replace("%LXCNAME%",lxc_name)
                 # tag = 0 is not allowed
-                content = content.replace("%VLANID%",str(vlanid % self.bridgeUserSize + 1))
+                content = content.replace("%VLANID%", str(vlanid % bridgeUserSize + 1))
                 content = content.replace("%CLUSTERNAME%", clustername)
                 content = content.replace("%VETHPAIR%", str(clusterid)+'-'+str(containerid))
                 content = content.replace("%MASTER%", str(self.masterIP))
-                content = content.replace("%BRIDGEID%", str(vlanid // self.bridgeUserSize))
+                content = content.replace("%BRIDGEID%", str(vlanid // bridgeUserSize))
                 return content
 
             conffile = open(self.confpath+"/container.conf", 'r')
             conftext = conffile.read()
             conffile.close()
-            conftext = config_prepare(conftext)
+            conftext = config_prepare(conftext,bridgeUserSize)
 
             conffile = open("/var/lib/lxc/%s/config" % lxc_name,"w")
             conffile.write(conftext)
@@ -83,7 +83,7 @@ class Container(object):
                 conffile = open(self.confpath+"/lxc.custom.conf", 'r')
                 conftext = conffile.read()
                 conffile.close()
-                conftext = config_prepare(conftext)
+                conftext = config_prepare(conftext,bridgeUserSize)
                 conffile = open("/var/lib/lxc/%s/config" % lxc_name, 'a')
                 conffile.write(conftext)
                 conffile.close()

--- a/src/container.py
+++ b/src/container.py
@@ -67,7 +67,7 @@ class Container(object):
                 content = content.replace("%VLANID%", str((vlanid % self.bridgeUserSize) + 1))
                 content = content.replace("%CLUSTERNAME%", clustername)
                 content = content.replace("%VETHPAIR%", str(clusterid)+'-'+str(containerid))
-                if self.addr != masterIP:
+                if self.addr != self.masterIP:
                     content = content.replace("%MASTER%", str(self.masterIP))
                 else:
                     #don't set the tunnel to itself

--- a/src/container.py
+++ b/src/container.py
@@ -66,9 +66,13 @@ class Container(object):
                 # tag = 0 is not allowed
                 content = content.replace("%VLANID%", str((vlanid % self.bridgeUserSize) + 1))
                 content = content.replace("%CLUSTERNAME%", clustername)
-                content = content.replace("%VETHPAIR%", username+str(clusterid)+'-'+str(containerid))
-                content = content.replace("%MASTER%", str(self.masterIP))
-                content = content.replace("%BRIDGEID%", str(vlanid // self.bridgeUserSize))
+                content = content.replace("%VETHPAIR%", str(clusterid)+'-'+str(containerid))
+                if self.addr != masterIP:
+                    content = content.replace("%MASTER%", str(self.masterIP))
+                else:
+                    #don't set the tunnel to itself
+                    content = content.replace("%MASTER%", "ERROR")
+                content = content.replace("%BRIDGEID%", str(vlanid // self.bridgeUserSize + 1))
                 return content
 
             conffile = open(self.confpath+"/container.conf", 'r')

--- a/src/env.py
+++ b/src/env.py
@@ -55,6 +55,6 @@ def getenv(key):
     elif key =="DATA_QUOTA_CMD":
         return os.environ.get("DATA_QUOTA_CMD", "gluster volume quota docklet-volume limit-usage %s %s")
     elif key =="VNET_COUNT":
-        return os.environ.get("VNET_COUNT", 4094)
+        return int(os.environ.get("VNET_COUNT", 4094))
     else:
         return os.environ[key]

--- a/src/env.py
+++ b/src/env.py
@@ -54,5 +54,7 @@ def getenv(key):
         return os.environ.get("DATA_QUOTA", "False")
     elif key =="DATA_QUOTA_CMD":
         return os.environ.get("DATA_QUOTA_CMD", "gluster volume quota docklet-volume limit-usage %s %s")
+    elif key =="VNET_COUNT":
+        return os.environ.get("VNET_COUNT", 4094)
     else:
         return os.environ[key]

--- a/src/nettools.py
+++ b/src/nettools.py
@@ -212,7 +212,7 @@ class ovscontrol(object):
          try:
             subprocess.run(['ovs-vsctl', 'add-port', str(bridge), str(port), '--', 'set', 'interface', str(port), 'type=vxlan', 'options:remote_ip='+str(remote), 'options:key='+str(key)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False, check=True)
             return [True, str(port)]
-        except subprocess.CalledProcessError as suberror:
+         except subprocess.CalledProcessError as suberror:
             return [False, "add port failed : %s" % suberror.stdout.decode('utf-8')]
                    
     @staticmethod

--- a/src/nettools.py
+++ b/src/nettools.py
@@ -116,6 +116,7 @@ class ipcontrol(object):
 # ovs-vsctl list-ports <Bridge>
 # ovs-vsctl del-port <Bridge> <Port>
 # ovs-vsctl add-port <Bridge> <Port> -- set interface <Port> type=gre options:remote_ip=<RemoteIP>
+# ovs-vsctl add-port <Bridge> <Port> -- set interface <Port> type=vxlan options:remote_ip=<RemoteIP> options:key=<Key>
 # ovs-vsctl add-port <Bridge> <Port> tag=<ID> -- set interface <Port> type=internal
 # ovs-vsctl port-to-br <Port>
 # ovs-vsctl set Port <Port> tag=<ID>
@@ -207,6 +208,14 @@ class ovscontrol(object):
             return [False, "add port failed : %s" % suberror.stdout.decode('utf-8')]
 
     @staticmethod
+    def add_port_vxlan(bridge, port, remote, key):
+         try:
+            subprocess.run(['ovs-vsctl', 'add-port', str(bridge), str(port), '--', 'set', 'interface', str(port), 'type=vxlan', 'options:remote_ip='+str(remote), 'options:key='+str(key)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False, check=True)
+            return [True, str(port)]
+        except subprocess.CalledProcessError as suberror:
+            return [False, "add port failed : %s" % suberror.stdout.decode('utf-8')]
+                   
+    @staticmethod
     def set_port_tag(port, tag):
         try:
             subprocess.run(['ovs-vsctl', 'set', 'Port', str(port), 'tag='+str(tag)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False, check=True)
@@ -232,11 +241,20 @@ class netcontrol(object):
     def gre_exists(bridge, remote):
         # port is unique, bridge is not necessary
         return ovscontrol.port_exists('gre-'+str(remote))
-
+    
+    @staticmethod
+    def vxlan_exists(bridge, remote):
+        # port is unique, bridge is not necessary
+        return ovscontrol.port_exists('vxlan-'+str(remote))
+    
     @staticmethod
     def setup_gre(bridge, remote):
         return ovscontrol.add_port_gre(bridge, 'gre-'+str(remote), remote)
 
+    @staticmethod
+    def setup_vxlan(bridge, remote, key):
+        return ovscontrol.add_port_vxlan(bridge, 'vxlan-'+str(key)+"-"+str(remote), remote, key)
+        
     @staticmethod
     def gw_exists(bridge, gwport):
         return ovscontrol.port_exists(gwport)

--- a/src/network.py
+++ b/src/network.py
@@ -350,15 +350,15 @@ class NetworkMgr(object):
         if not status:
             logger.error("acquire_vlanid get key error")
             return [False, currentid]
-        currenid = int(currentid);
+        currentid = int(currentid)
         [status, maxid] = self.etcd.getkey("network/vlanids/total")
         if not status:
             logger.error("acquire_vlanid get key error")
             return [False, currentid]
-        if maxid < currentid:
+        if int(maxid) < currentid:
             logger.error("No more VlanID")
             return [False, currentid]
-        nextid = currentid + 1;
+        nextid = currentid + 1
         self.etcd.setkey("network/vlanids/current", str(nextid))
         return [True, currentid]
 
@@ -403,7 +403,6 @@ class NetworkMgr(object):
         logger.info ("delete user %s with cidr=%s" % (username, int(cidr)))
         self.center.free(addr, int(cidr))
         self.dump_center()
-        self.release_vlanid(self.users[username].vlanid)
         vlanid = self.users[username].vlanid
         bridgeid = vlanid / self.bridgeUserSize
         netcontrol.del_gw('docklet-br'+str(bridgeid), username)

--- a/src/network.py
+++ b/src/network.py
@@ -425,7 +425,7 @@ class NetworkMgr(object):
             return [False, vlanid]
         self.users[username] = UserPool(addr_cidr = result+"/"+str(cidr), vlanid=vlanid)
         logger.info("setup gateway for %s with %s and vlan=%s" % (username, self.users[username].get_gateway_cidr(), str(vlanid)))
-        bridgeid = vlanid / self.bridgeUserSize
+        bridgeid = vlanid // self.bridgeUserSize
         hasBridge = netcontrol.bridge_exists("docklet-br-"+str(bridgeid))
         if not hasBridge:
             netcontrol.new_bridge("docklet-br-"+str(bridgeid));
@@ -433,7 +433,7 @@ class NetworkMgr(object):
             if status:
                 for node in nodeinfo:
                     nodeip = node["key"].rsplit('/', 1)[1];
-                    netcontrol.setup_vxlan("docklet-br-"+str(bridgeid), nodeip, vlanid);
+                    netcontrol.setup_vxlan("docklet-br-"+str(bridgeid), nodeip, bridgeid);
             else:
                 return [False, nodeinfo]
         netcontrol.setup_gw("docklet-br-"+str(bridgeid), username, self.users[username].get_gateway_cidr(), str(vlanid))

--- a/src/network.py
+++ b/src/network.py
@@ -240,7 +240,7 @@ class EnumPool(object):
 # wrap EnumPool with vlanid and gateway
 class UserPool(EnumPool):
     def __init__(self, addr_cidr=None, vlanid=None, copy=None):
-        if addr_cidr and vlanid:
+        if addr_cidr and vlanid != None:
             EnumPool.__init__(self, addr_cidr = addr_cidr)
             self.vlanid=vlanid
             self.pool.sort(key=ip_to_int)

--- a/src/network.py
+++ b/src/network.py
@@ -342,16 +342,16 @@ class NetworkMgr(object):
         print ("<users>")
         print ("    users in users is in etcd, not in memory")
         print ("<vlanids>")
-        [status, currentid] = self.etcd.getkey("network/vlanid/current")
+        [status, currentid] = self.etcd.getkey("network/vlanids/current")
         print ("Current vlanid:"+currentid)
 
     def acquire_vlanid(self):
-        [status, currentid] = self.etcd.getkey("network/vlanid/current")
+        [status, currentid] = self.etcd.getkey("network/vlanids/current")
         if not status:
             logger.error("acquire_vlanid get key error")
             return [False, currentid]
         currenid = int(currentid);
-        [status, maxid] = self.etcd.getkey("network/vlanid/total")
+        [status, maxid] = self.etcd.getkey("network/vlanids/total")
         if not status:
             logger.error("acquire_vlanid get key error")
             return [False, currentid]
@@ -359,7 +359,7 @@ class NetworkMgr(object):
             logger.error("No more VlanID")
             return [False, currentid]
         nextid = currentid + 1;
-        self.etcd.setkey("network/vlanid/current", str(nextid))
+        self.etcd.setkey("network/vlanids/current", str(nextid))
         return [True, currentid]
 
     def add_user(self, username, cidr):

--- a/src/network.py
+++ b/src/network.py
@@ -305,7 +305,6 @@ class NetworkMgr(object):
             self.load_center()
             self.load_system()
             self.load_vlanids()
-            self.load_shared_vlanids()
         else:
             logger.error("mode: %s not supported" % mode)
 

--- a/src/nodemgr.py
+++ b/src/nodemgr.py
@@ -37,14 +37,14 @@ class NodeMgr(object):
         #logger.info ("initialize bridge wih ip %s" % self.bridgeip)
         #network.netsetup("init", self.bridgeip)
 
-        if self.mode == 'new':
-            if netcontrol.bridge_exists('docklet-br'):
-                netcontrol.del_bridge('docklet-br')
-            netcontrol.new_bridge('docklet-br')
-        else:
-            if not netcontrol.bridge_exists('docklet-br'):
-                logger.error("docklet-br not found")
-                sys.exit(1)
+        #if self.mode == 'new':
+        #    if netcontrol.bridge_exists('docklet-br'):
+        #        netcontrol.del_bridge('docklet-br')
+        #    netcontrol.new_bridge('docklet-br')
+        #else:
+        #    if not netcontrol.bridge_exists('docklet-br'):
+        #        logger.error("docklet-br not found")
+        #        sys.exit(1)
 
         # init rpc list 
         self.rpcs = []
@@ -115,10 +115,10 @@ class NodeMgr(object):
                         logger.debug ("worker start on master node. not need to setup GRE")
                     else:
                         logger.debug ("setup GRE for %s" % nodeip)
-                        if netcontrol.gre_exists('docklet-br', nodeip):
-                            logger.debug("GRE for %s already exists, reuse it" % nodeip)
-                        else:
-                            netcontrol.setup_gre('docklet-br', nodeip)
+                        #if netcontrol.gre_exists('docklet-br', nodeip):
+                        #    logger.debug("GRE for %s already exists, reuse it" % nodeip)
+                        #else:
+                        #    netcontrol.setup_gre('docklet-br', nodeip)
                     self.etcd.setkey("machines/runnodes/"+nodeip, "ok")
                     if nodeip not in self.runnodes:
                         self.runnodes.append(nodeip)

--- a/src/vclustermgr.py
+++ b/src/vclustermgr.py
@@ -65,7 +65,7 @@ class VclusterMgr(object):
             return [False, "no workers are running"]
         # check user IP pool status, should be moved to user init later
         if not self.networkmgr.has_user(username):
-            self.networkmgr.add_user(username, cidr=29, isshared = True if str(groupname) == "fundation" else False)
+            self.networkmgr.add_user(username, cidr=29)
         [status, result] = self.networkmgr.acquire_userips_cidr(username, clustersize)
         gateway = self.networkmgr.get_usergw(username)
         vlanid = self.networkmgr.get_uservlanid(username)
@@ -254,7 +254,7 @@ class VclusterMgr(object):
         groupname = json.loads(user_info)["data"]["group"]
         [status, clusters] = self.list_clusters(username)
         if len(clusters) == 0:
-            self.networkmgr.del_user(username, isshared = True if str(groupname) == "fundation" else False)
+            self.networkmgr.del_user(username)
             logger.info("vlanid release triggered")
         
         return [True, "cluster delete"]

--- a/src/worker.py
+++ b/src/worker.py
@@ -142,18 +142,18 @@ class Worker(object):
             #self.bridgeip = result
             # create bridges for worker
             #network.netsetup("init", self.bridgeip)
-            if self.mode == 'new':
-                if netcontrol.bridge_exists('docklet-br'):
-                    netcontrol.del_bridge('docklet-br')
-                netcontrol.new_bridge('docklet-br')
-            else:
-                if not netcontrol.bridge_exists('docklet-br'):
-                    logger.error("docklet-br not found")
-                    sys.exit(1)
-            logger.info ("setup GRE tunnel to master %s" % self.master)
+            #if self.mode == 'new':
+            #    if netcontrol.bridge_exists('docklet-br'):
+            #        netcontrol.del_bridge('docklet-br')
+            #    netcontrol.new_bridge('docklet-br')
+            #else:
+            #    if not netcontrol.bridge_exists('docklet-br'):
+            #        logger.error("docklet-br not found")
+            #        sys.exit(1)
+            #logger.info ("setup GRE tunnel to master %s" % self.master)
             #network.netsetup("gre", self.master)
-            if not netcontrol.gre_exists('docklet-br', self.master):
-                netcontrol.setup_gre('docklet-br', self.master)
+            #if not netcontrol.gre_exists('docklet-br', self.master):
+            #    netcontrol.setup_gre('docklet-br', self.master)
 
     # start service of worker
     def start(self):


### PR DESCRIPTION
1. 修正Vlanid从0开始分配，tag计算方法为（Vlanid % VNET_COUNT） + 1，vxlanid（bridgeid）的计算方式位（Vlanid // VNET_COUNT）+ 1
这样VLAN tag 是从1 - VNET_COUNT，VxLANid（bridgeid）是从1-2^24

2. 修复单机会出现多余Vxlan tunnel的情况，修复方式为在add_user中创建Vxlan tunnel前判断隧道终点ip与etcd中master的ip是否相同，相同则不执行。
    同时，在container.py中做类似的处理，如果是masterip，则在对container.conf的替换中不使用master的ip而是使用特殊标记“ERROR”，在lxc-up的script里面，则判断不是ERROR标记才会建立隧道

3. 这次是在单机和两台虚拟机的情况下做过了测试，正常，之前是我弄错了...我之前一直以为ip是localhost:8888，后来才发现那个好像是后台web代理的端口，使用8000则不会出现之前的问题