### PR TITLE
prevent fork bomb

### DIFF
--- a/conf/container.conf
+++ b/conf/container.conf
@@ -32,6 +32,7 @@ lxc.network.ipv4.gateway = %GATEWAY%
 lxc.network.flags = up
 lxc.network.mtu = 1420
 
+lxc.cgroup.pids.max = 2048
 lxc.cgroup.memory.limit_in_bytes = %CONTAINER_MEMORY%M
 #lxc.cgroup.memory.kmem.limit_in_bytes = 512M
 #lxc.cgroup.memory.soft_limit_in_bytes = 4294967296


### PR DESCRIPTION
Allow at most 2048 threads + processes (using around 1G kernel memory)